### PR TITLE
세부목표 엔터 버그 수정

### DIFF
--- a/components/schedule-form.tsx
+++ b/components/schedule-form.tsx
@@ -556,6 +556,7 @@ export function ScheduleForm({ schedule, onSubmit, onCancel, onDelete, defaultDa
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   e.preventDefault()
+                  e.stopPropagation() // 이벤트 전파 중단 추가
                   addSubTask()
                 }
               }}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #30 

## 📝 수정 요약

- 🚨 문제점
    - 한번의 엔터로 두개의 같은 세부 목표 생성

- 🔍 원인 분석
    - 현재 Input 필드의 onKeyDown 이벤트 핸들러에서 addSubTask()를 호출하고 있지만, Enter 키를
  누르면 브라우저의 기본 동작으로 인해 폼 전체가 제출. handleSubmit 내부에 e.preventDefault()가 있지만, onKeyDown 이벤트가
  폼의 onSubmit 이벤트까지 전파되어 문제가 발생

- 💡 해결 방법
    - e.stopPropagation()을 추가하여 이벤트 전파방지

## 🛠️ PR 유형
- [ ] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
