### PR TITLE
[feat] 새 세션 진입 시 오늘로 포커스 / 사용 중에는 마지막 선택값 유지

### DIFF
--- a/app/goal/goal-page-client.tsx
+++ b/app/goal/goal-page-client.tsx
@@ -11,7 +11,6 @@ import { ScheduleCalendar } from "@/components/schedule-calendar"
 import { GoalForm } from "@/components/goal-form"
 import { SubGoalModal, type SubGoalModalData } from "@/components/subgoal-modal"
 import { RetrospectiveFlow } from "@/components/retrospective/retrospective-flow"
-import { toKoreanISOString } from "@/lib/korean-time"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -30,6 +29,8 @@ interface SubGoal {
   color?: string
 }
 
+let lastGoalPageSelectedDate: Date | null = null
+
 export default function GoalPageClient() {
   const router = useRouter()
   const { status: authStatus, markUnauthenticated } = useAuth()
@@ -39,17 +40,7 @@ export default function GoalPageClient() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedDate, setSelectedDate] = useState(() => {
-    // 페이지 로드 시 localStorage에서 날짜 복원
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('goalPageSelectedDate')
-      if (saved) {
-        const date = new Date(saved)
-        if (!isNaN(date.getTime())) {
-          return date
-        }
-      }
-    }
-    return new Date()
+    return lastGoalPageSelectedDate ? new Date(lastGoalPageSelectedDate) : new Date()
   })
   const [expandedGoals, setExpandedGoals] = useState<Set<number>>(new Set())
   const [subGoalsMap, setSubGoalsMap] = useState<Record<number, SubGoal[]>>({})
@@ -69,17 +60,19 @@ export default function GoalPageClient() {
 
   useEffect(() => {
     if (authStatus === "unauthenticated") {
+      lastGoalPageSelectedDate = null
       router.replace("/login")
     }
   }, [authStatus, router])
 
-  // 날짜 변경 시 localStorage에 저장
+  // 날짜 변경 시 세션 내 선택값 유지
   const handleDateSelect = (date: Date) => {
     setSelectedDate(date)
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('goalPageSelectedDate', toKoreanISOString(date))
-    }
   }
+
+  useEffect(() => {
+    lastGoalPageSelectedDate = new Date(selectedDate)
+  }, [selectedDate])
 
   const fetchGoals = useCallback(
     async (date: Date) => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #56 

## 📝 수정 요약
목표 화면 기본 진입 포커스는 “오늘” 또는 “마지막으로 사용자가 본 날짜” 중 하나로 정책 고정(권장: 오늘)

- 🚨 문제점
    - 목표 화면 진입 시 “오늘”이 아니라 가장 최근 추가된 목표 날짜로 열림.

- 🔍 원인 분석
    - localstorage 값이 삭제되지 않고 페이지를 닫아도 남아있음 (추정)

- 💡 해결 방법
    - 세션에서 날짜 유지, localstorage에서 날짜 삭제

## 🛠️ PR 유형
- [ ] 버그 수정
- [ ] 테스트 리팩토링
- [x] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
3+
