### PR TITLE
[fix] 목표와 일정 계산 분리, 각 개수별로 포인트 캘린더에 표시

### DIFF
--- a/app/goal/goal-page-client.tsx
+++ b/app/goal/goal-page-client.tsx
@@ -594,6 +594,7 @@ export default function GoalPageClient() {
                   onDateSelect={handleDateSelect}
                   schedules={[]}
                   goals={goals}
+                  showSchedules={false}
                 />
               </CardContent>
             </Card>

--- a/components/schedule-calendar.tsx
+++ b/components/schedule-calendar.tsx
@@ -29,11 +29,20 @@ interface ScheduleCalendarProps {
   onDateSelect: (date: Date) => void
   schedules: Schedule[]
   goals?: Goal[]
+  showSchedules?: boolean
   onClose?: () => void
   refreshTrigger?: number
 }
 
-export function ScheduleCalendar({ selectedDate, onDateSelect, schedules, goals = [], onClose, refreshTrigger }: ScheduleCalendarProps) {
+export function ScheduleCalendar({
+  selectedDate,
+  onDateSelect,
+  schedules,
+  goals = [],
+  showSchedules = true,
+  onClose,
+  refreshTrigger,
+}: ScheduleCalendarProps) {
   const router = useRouter()
   const [currentMonth, setCurrentMonth] = useState(new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1))
   const [monthlyPlans, setMonthlyPlans] = useState<DailyPlan[]>([]);
@@ -50,6 +59,10 @@ export function ScheduleCalendar({ selectedDate, onDateSelect, schedules, goals 
 
   useEffect(() => {
     const fetchMonthlyPlans = async () => {
+      if (!showSchedules) {
+        setMonthlyPlans([]);
+        return;
+      }
       setLoadingMonthlyPlans(true);
       try {
         const year = currentMonth.getFullYear();
@@ -72,7 +85,7 @@ export function ScheduleCalendar({ selectedDate, onDateSelect, schedules, goals 
       }
     };
     fetchMonthlyPlans();
-  }, [currentMonth, router, refreshTrigger]);
+  }, [currentMonth, router, refreshTrigger, showSchedules]);
 
   const daysInMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0).getDate()
   const firstDayOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1).getDay()
@@ -169,9 +182,10 @@ export function ScheduleCalendar({ selectedDate, onDateSelect, schedules, goals 
       date.setHours(0, 0, 0, 0)
       const isToday = today ? date.getTime() === today.getTime() : false
       const isSelected = date.getTime() === selectedDate.getTime()
-      const daySchedules = getMonthlySchedulesForDate(date)
+      const daySchedules = showSchedules ? getMonthlySchedulesForDate(date) : []
       const dayGoals = getGoalsForDate(date)
-      const hasSchedules = daySchedules.length > 0 || dayGoals.length > 0
+      const totalItemsCount = showSchedules ? daySchedules.length : dayGoals.length
+      const hasSchedules = totalItemsCount > 0
 
       days.push(
         <button
@@ -190,25 +204,12 @@ export function ScheduleCalendar({ selectedDate, onDateSelect, schedules, goals 
           <span className={isToday && !isSelected ? "font-bold" : ""}>{day}</span>
           {hasSchedules && (
             <div className="absolute bottom-1.5 flex gap-0.5">
-              {daySchedules.length === 1 && (
-                <div className="h-1 w-1 rounded-full bg-[#ff8b6b]" />
-              )}
-              {daySchedules.length === 2 && (
-                <>
-                  <div className="h-1 w-1 rounded-full bg-[#ff8b6b]" />
-                  <div className="h-1 w-1 rounded-full bg-[#ff8b6b]" />
-                </>
-              )}
-              {daySchedules.length === 3 && (
-                <>
-                  <div className="h-1 w-1 rounded-full bg-[#ff8b6b]" />
-                  <div className="h-1 w-1 rounded-full bg-[#ff8b6b]" />
-                  <div className="h-1 w-1 rounded-full bg-[#ff8b6b]" />
-                </>
-              )}
-              {daySchedules.length >= 4 && (
-                <div className="h-1 w-4 rounded-full bg-[#ff8b6b]" />
-              )}
+              {totalItemsCount >= 4 && <div className="h-1 w-4 rounded-full bg-[#ff8b6b]" />}
+              {totalItemsCount > 0 &&
+                totalItemsCount < 4 &&
+                Array.from({ length: totalItemsCount }).map((_, index) => (
+                  <div key={index} className="h-1 w-1 rounded-full bg-[#ff8b6b]" />
+                ))}
             </div>
           )}
         </button>,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #57

## 📝 수정 요약
동일 데이터로 재조회/새로고침 시 표시 결과가 항상 동일
(일정/목표 각각) 캘린더 표시(점/마커/리스트)가 목표 데이터와 1:1로 일관되게 반영됨

- 🚨 문제점
    - 캘린더 표시(점/마커/리스트)가 목표 데이터와 1:1로 일관되게 반영되지 않았음

- 🔍 원인 분석
    - 이유는 캘린더 마커가 목표가 아니라 일정기준으로 그림. ScheduleCalendar에서 dayGoals를 구하긴 했지만, 마커 개수/표시는 daySchedules.length만 보고 결정해서 랜덤처럼 보임

- 💡 해결 방법
    - schedule-calendar.tsx에 showSchedules 옵션 추가(기본 true)
    - /goal에서 showSchedules={false}로 전달, 마커 계산은 목표만 기준(dayGoals.length)

## 🛠️ PR 유형
- [x] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
1+
