### PR TITLE
[feat] 수정 모달에 삭제 버튼 추가

### DIFF
--- a/app/goal/goal-page-client.tsx
+++ b/app/goal/goal-page-client.tsx
@@ -442,22 +442,21 @@ export default function GoalPageClient() {
     setShowGoalDeleteModal(true);
   };
 
-  const confirmDeleteGoal = async () => {
-    if (!goalToDelete) return;
-
-    setDeletingGoalId(goalToDelete);
+  const deleteGoalById = async (goalId: number) => {
+    setDeletingGoalId(goalId);
     try {
-      await deleteBigGoal(goalToDelete);
-      if (editingGoal?.goalId === goalToDelete) {
+      await deleteBigGoal(goalId);
+      if (editingGoal?.goalId === goalId) {
         setEditingGoal(null);
         setIsFormOpen(false);
       }
       await refreshGoals();
       setExpandedGoals((prev) => {
         const next = new Set(prev);
-        next.delete(goalToDelete);
+        next.delete(goalId);
         return next;
       });
+      setActionMenuGoalId((prev) => (prev === goalId ? null : prev));
     } catch (error: any) {
       console.error(error);
       if (error.response?.data?.message) {
@@ -467,6 +466,15 @@ export default function GoalPageClient() {
       }
     } finally {
       setDeletingGoalId(null);
+    }
+  };
+
+  const confirmDeleteGoal = async () => {
+    if (!goalToDelete) return;
+
+    try {
+      await deleteGoalById(goalToDelete);
+    } finally {
       setShowGoalDeleteModal(false);
       setGoalToDelete(null);
     }
@@ -959,6 +967,7 @@ export default function GoalPageClient() {
             <GoalForm
               goal={editingGoal}
               onSubmit={editingGoal ? (data) => updateGoal(editingGoal.goalId, data) : createGoal}
+              onDelete={editingGoal ? () => deleteGoalById(editingGoal.goalId) : undefined}
               onCancel={() => {
                 setIsFormOpen(false)
                 setEditingGoal(null)

--- a/app/templates/templates-page-client.tsx
+++ b/app/templates/templates-page-client.tsx
@@ -237,17 +237,25 @@ export default function TemplatesPageClient() {
     if (templateToDelete === null) return;
 
     try {
-      await deleteTemplate(templateToDelete);
-      const response = await fetchTemplatesData();
-      applyTemplateResponse(response);
-      if (response.content.length === 0 && currentPage > 1) {
-        setCurrentPage((prev) => Math.max(1, prev - 1));
-      }
+      await deleteTemplateById(templateToDelete);
     } catch (err) {
       handleTemplateApiError(err, '템플릿 삭제');
     } finally {
       setShowDeleteModal(false);
       setTemplateToDelete(null);
+    }
+  };
+
+  const deleteTemplateById = async (templateId: number) => {
+    await deleteTemplate(templateId);
+    const response = await fetchTemplatesData();
+    applyTemplateResponse(response);
+    if (response.content.length === 0 && currentPage > 1) {
+      setCurrentPage((prev) => Math.max(1, prev - 1));
+    }
+    if (editingTemplate?.templateId === templateId) {
+      setEditingTemplate(null);
+      setShowForm(false);
     }
   };
 
@@ -530,6 +538,11 @@ export default function TemplatesPageClient() {
                 setShowForm(false);
                 setEditingTemplate(null);
               }}
+              onDelete={
+                editingTemplate
+                  ? () => deleteTemplateById(editingTemplate.templateId)
+                  : undefined
+              }
             />
           </div>
         </div>

--- a/components/goal-form.tsx
+++ b/components/goal-form.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { X, Calendar, Flag, Palette, Sparkles } from "lucide-react"
 import { toKoreanDateString } from "@/lib/korean-time"
+import { ConfirmationModal } from "@/components/ui/confirmation-modal"
 
 interface Goal {
   goalId: number
@@ -28,10 +29,12 @@ interface GoalFormProps {
   goal?: Goal | null
   onSubmit: (data: any) => void
   onCancel: () => void
+  onDelete?: () => void | Promise<void>
   defaultDate?: Date
 }
 
-export function GoalForm({ goal, onSubmit, onCancel, defaultDate }: GoalFormProps) {
+export function GoalForm({ goal, onSubmit, onCancel, onDelete, defaultDate }: GoalFormProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const initialStartDate = goal?.startDate || (defaultDate ? toKoreanDateString(defaultDate) : toKoreanDateString())
   const initialEndDate = goal?.endDate || (defaultDate ? toKoreanDateString(defaultDate) : toKoreanDateString())
   
@@ -163,6 +166,12 @@ export function GoalForm({ goal, onSubmit, onCancel, defaultDate }: GoalFormProp
       case "LOW": return "낮음"
       default: return priority
     }
+  }
+
+  const handleDelete = async () => {
+    if (!goal || !goal.goalId || !onDelete) return
+    await onDelete()
+    setShowDeleteConfirm(false)
   }
 
   return (
@@ -346,6 +355,16 @@ export function GoalForm({ goal, onSubmit, onCancel, defaultDate }: GoalFormProp
             >
               취소
             </Button>
+            {goal && goal.goalId > 0 && onDelete && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="flex-1 h-12 rounded-2xl border-2 border-[#FFD7D1] bg-white text-[#d85b48] font-semibold hover:bg-[#FFECEA] transition-all"
+              >
+                삭제
+              </Button>
+            )}
             <Button
               type="submit"
               className="flex-1 h-12 rounded-2xl bg-gradient-to-r from-[#ff8b6b] to-[#ff6b47] text-white font-bold shadow-lg hover:shadow-xl hover:scale-[1.02] transition-all"
@@ -354,6 +373,15 @@ export function GoalForm({ goal, onSubmit, onCancel, defaultDate }: GoalFormProp
             </Button>
           </div>
         </form>
+
+        <ConfirmationModal
+          isOpen={showDeleteConfirm}
+          onClose={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+          title="목표 삭제 확인"
+          message="정말로 이 목표를 삭제하시겠습니까?"
+          confirmText="삭제"
+        />
     </div>
   )
 }

--- a/components/schedule-form.tsx
+++ b/components/schedule-form.tsx
@@ -592,6 +592,16 @@ export function ScheduleForm({ schedule, onSubmit, onCancel, onDelete, defaultDa
           >
             취소
           </Button>
+          {schedule && onDelete && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setShowDeleteModal(true)}
+              className="flex-1 h-12 rounded-2xl border-2 border-[#FFD7D1] bg-white text-[#d85b48] font-semibold hover:bg-[#FFECEA] transition-all"
+            >
+              삭제
+            </Button>
+          )}
           <Button
             type="submit"
             className="flex-1 h-12 rounded-2xl bg-gradient-to-r from-[#ff8b6b] to-[#ff6b47] text-white font-bold shadow-lg hover:shadow-xl hover:scale-[1.02] transition-all"
@@ -599,18 +609,6 @@ export function ScheduleForm({ schedule, onSubmit, onCancel, onDelete, defaultDa
             {schedule ? "수정 완료" : "일정 만들기"}
           </Button>
         </div>
-
-        {schedule && onDelete && (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setShowDeleteModal(true)}
-            className="w-full h-12 rounded-2xl border-2 border-red-200 text-red-600 font-semibold hover:bg-red-50"
-          >
-            <Trash2 className="h-4 w-4 mr-2" />
-            일정 삭제
-          </Button>
-        )}
       </form>
 
       <ConfirmationModal

--- a/components/subgoal-modal.tsx
+++ b/components/subgoal-modal.tsx
@@ -310,6 +310,16 @@ export function SubGoalModal({
               >
                 취소
               </Button>
+              {isEditMode && onDelete && editingSubGoal && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setShowDeleteModal(true)}
+                  className="flex-1 h-12 rounded-2xl border-2 border-[#FFD7D1] bg-white text-[#d85b48] font-semibold hover:bg-[#FFECEA] transition-all"
+                >
+                  삭제
+                </Button>
+              )}
               <Button
                   onClick={handleSubmit}
                   disabled={!title.trim() || loading}
@@ -318,19 +328,6 @@ export function SubGoalModal({
                 {loading ? `${isEditMode ? '수정' : '추가'} 중...` : isEditMode ? "수정 완료" : "소목표 추가"}
               </Button>
             </div>
-
-            {/* Delete Button - 편집 모드일 때만 표시 */}
-            {isEditMode && onDelete && editingSubGoal && (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setShowDeleteModal(true)}
-                className="w-full h-12 rounded-2xl border-2 border-red-200 text-red-600 font-semibold hover:bg-red-50"
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                세부목표 삭제
-              </Button>
-            )}
           </div>
         </div>
 

--- a/components/template-form.tsx
+++ b/components/template-form.tsx
@@ -17,9 +17,10 @@ interface TemplateFormProps {
   template?: Template | null;
   onSubmit: (data: Omit<Template, 'templateId'>) => void;
   onCancel: () => void;
+  onDelete?: () => void | Promise<void>;
 }
 
-export function TemplateForm({ template, onSubmit, onCancel }: TemplateFormProps) {
+export function TemplateForm({ template, onSubmit, onCancel, onDelete }: TemplateFormProps) {
   const [title, setTitle] = useState('');
   const [priority, setPriority] = useState<'HIGH' | 'MEDIUM' | 'LOW'>('MEDIUM');
   const [duration, setDuration] = useState<number | ''>('');
@@ -32,6 +33,7 @@ export function TemplateForm({ template, onSubmit, onCancel }: TemplateFormProps
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [subTemplateToDelete, setSubTemplateToDelete] = useState<number | null>(null);
+  const [showTemplateDeleteModal, setShowTemplateDeleteModal] = useState(false);
 
   useEffect(() => {
     if (template) {
@@ -120,6 +122,12 @@ export function TemplateForm({ template, onSubmit, onCancel }: TemplateFormProps
       )
     );
     handleCancelEditSubTemplate();
+  };
+
+  const handleDeleteTemplate = async () => {
+    if (!template || !template.templateId || !onDelete) return;
+    await onDelete();
+    setShowTemplateDeleteModal(false);
   };
 
   const getPriorityLabel = (p: 'HIGH' | 'MEDIUM' | 'LOW') => {
@@ -293,6 +301,16 @@ export function TemplateForm({ template, onSubmit, onCancel }: TemplateFormProps
           >
             취소
           </Button>
+          {template && template.templateId > 0 && onDelete && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setShowTemplateDeleteModal(true)}
+              className="flex-1 h-12 rounded-2xl border-2 border-[#FFD7D1] bg-white text-[#d85b48] font-semibold hover:bg-[#FFECEA] transition-all"
+            >
+              삭제
+            </Button>
+          )}
           <Button
             type="submit"
             className="flex-1 h-12 rounded-2xl bg-gradient-to-r from-[#ff8b6b] to-[#ff6b47] text-white font-bold shadow-lg hover:shadow-xl hover:scale-[1.02] transition-all"
@@ -308,6 +326,15 @@ export function TemplateForm({ template, onSubmit, onCancel }: TemplateFormProps
         onConfirm={confirmRemoveSubTemplate}
         title="하위 템플릿 삭제"
         message="정말로 이 하위 템플릿을 삭제하시겠습니까?"
+        confirmText="삭제"
+      />
+
+      <ConfirmationModal
+        isOpen={showTemplateDeleteModal}
+        onClose={() => setShowTemplateDeleteModal(false)}
+        onConfirm={handleDeleteTemplate}
+        title="템플릿 삭제 확인"
+        message="정말로 이 템플릿을 삭제하시겠습니까?"
         confirmText="삭제"
       />
     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #59 

## 🚀 작업 내용
- [x] goal / template 수정 모달에 삭제 버튼 추가
- [x] schdule / subgoal 모달에 취소-삭제-저장 버튼 가로 일렬(웹) 세로 일렬(모바일)

## 🔍 리뷰 요청 사항 및 공유자료


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
3+
