### PR TITLE
[feat] 월별 캘린더 조회 적용

### DIFF
--- a/api/goals.ts
+++ b/api/goals.ts
@@ -31,6 +31,24 @@ export interface GetGoalsParams {
   status?: 'IN_PROGRESS' | 'COMPLETED' | 'EXPIRED';
 }
 
+export interface DailyGoalCount {
+  date: string;
+  goal_count: number;
+}
+
+export interface MonthlyGoalCountResult {
+  year: number;
+  month: number;
+  daily_goals: DailyGoalCount[];
+}
+
+export interface GetMonthlyGoalCountResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: MonthlyGoalCountResult;
+}
+
 export const getGoals = async (params: GetGoalsParams): Promise<Goal[]> => {
   const response = await axiosInstance.get('/goals', { params });
   const apiGoals = response.data.result;
@@ -68,6 +86,13 @@ export const getGoals = async (params: GetGoalsParams): Promise<Goal[]> => {
       updatedAt: g.updatedAt,
     };
   });
+};
+
+export const getMonthlyGoalCounts = async (year: number, month: number): Promise<MonthlyGoalCountResult> => {
+  const response = await axiosInstance.get<GetMonthlyGoalCountResponse>('/goals/monthly/count', {
+    params: { year, month },
+  });
+  return response.data.result;
 };
 
 //----------------------------------대목표 삭제 api---------------------------------

--- a/app/goal/goal-page-client.tsx
+++ b/app/goal/goal-page-client.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation"
 import { useState, useEffect, useCallback } from "react"
 import { Plus, Calendar, Target, CheckCircle2, ChevronDown, ChevronRight, Pencil, Trash2, MoreHorizontal } from "lucide-react"
-import { getGoals, Goal, deleteBigGoal } from "@/api/goals"
+import { getGoals, getMonthlyGoalCounts, deleteBigGoal, Goal } from "@/api/goals"
 import { update_Goal as updateGoalApi, type UpdateGoalRequest } from "@/api/updateGoal"
 import { createGoal as createGoalApi } from "@/api/createGoal"
 import { getSubGoals, deleteSubGoal, updateSubGoal } from "@/api/subgoals"
@@ -51,6 +51,7 @@ export default function GoalPageClient() {
   const [retrospectiveGoal, setRetrospectiveGoal] = useState<Goal | null>(null)
   const [deletingGoalId, setDeletingGoalId] = useState<number | null>(null)
   const [actionMenuGoalId, setActionMenuGoalId] = useState<number | null>(null)
+  const [monthlyGoalCounts, setMonthlyGoalCounts] = useState<Record<string, number>>({})
 
   const [showGoalDeleteModal, setShowGoalDeleteModal] = useState(false);
   const [goalToDelete, setGoalToDelete] = useState<number | null>(null);
@@ -101,6 +102,30 @@ export default function GoalPageClient() {
         }
       } finally {
         setLoading(false)
+      }
+    },
+    [router, markUnauthenticated]
+  )
+
+  const fetchMonthlyGoalCounts = useCallback(
+    async (date: Date) => {
+      try {
+        const year = date.getFullYear()
+        const month = date.getMonth() + 1
+        const result = await getMonthlyGoalCounts(year, month)
+        const counts = result.daily_goals.reduce<Record<string, number>>((acc, item) => {
+          acc[item.date] = item.goal_count
+          return acc
+        }, {})
+        setMonthlyGoalCounts(counts)
+      } catch (err: any) {
+        if (err.response?.status === 401 || err.response?.status === 403) {
+          markUnauthenticated()
+          alert(err.response?.data?.message || "인증에 실패했습니다. 다시 로그인해주세요.")
+          router.push("/login")
+        } else {
+          console.error(err)
+        }
       }
     },
     [router, markUnauthenticated]
@@ -603,6 +628,8 @@ export default function GoalPageClient() {
                   schedules={[]}
                   goals={goals}
                   showSchedules={false}
+                  dailyGoalCounts={monthlyGoalCounts}
+                  onMonthChange={fetchMonthlyGoalCounts}
                 />
               </CardContent>
             </Card>

--- a/components/schedule-calendar.tsx
+++ b/components/schedule-calendar.tsx
@@ -29,9 +29,11 @@ interface ScheduleCalendarProps {
   onDateSelect: (date: Date) => void
   schedules: Schedule[]
   goals?: Goal[]
+  dailyGoalCounts?: Record<string, number>
   showSchedules?: boolean
   onClose?: () => void
   refreshTrigger?: number
+  onMonthChange?: (date: Date) => void
 }
 
 export function ScheduleCalendar({
@@ -39,9 +41,11 @@ export function ScheduleCalendar({
   onDateSelect,
   schedules,
   goals = [],
+  dailyGoalCounts = {},
   showSchedules = true,
   onClose,
   refreshTrigger,
+  onMonthChange,
 }: ScheduleCalendarProps) {
   const router = useRouter()
   const [currentMonth, setCurrentMonth] = useState(new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1))
@@ -87,6 +91,10 @@ export function ScheduleCalendar({
     fetchMonthlyPlans();
   }, [currentMonth, router, refreshTrigger, showSchedules]);
 
+  useEffect(() => {
+    onMonthChange?.(currentMonth);
+  }, [currentMonth, onMonthChange]);
+
   const daysInMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0).getDate()
   const firstDayOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1).getDay()
 
@@ -114,6 +122,13 @@ export function ScheduleCalendar({
       checkDate.setHours(0, 0, 0, 0);
       return checkDate >= startDate && checkDate <= endDate;
     });
+  };
+
+  const getGoalCountForDate = (date: Date) => {
+    const formattedDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+    const monthlyCount = dailyGoalCounts[formattedDate];
+    if (typeof monthlyCount === "number") return monthlyCount;
+    return getGoalsForDate(date).length;
   };
 
   const renderCalendarDays = () => {
@@ -183,8 +198,7 @@ export function ScheduleCalendar({
       const isToday = today ? date.getTime() === today.getTime() : false
       const isSelected = date.getTime() === selectedDate.getTime()
       const daySchedules = showSchedules ? getMonthlySchedulesForDate(date) : []
-      const dayGoals = getGoalsForDate(date)
-      const totalItemsCount = showSchedules ? daySchedules.length : dayGoals.length
+      const totalItemsCount = showSchedules ? daySchedules.length : getGoalCountForDate(date)
       const hasSchedules = totalItemsCount > 0
 
       days.push(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #80

## 🚀 작업 내용
- [x] `/api/v1/goals/months/count` API를 적용해 캘린더에 월별 목표가 나타나도록 수정했습니다.

## 🔍 리뷰 요청 사항 및 공유자료
- 캘린더에 월별 목표가 포인트로 표시되는지 확인해주세요.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
3+
